### PR TITLE
unlock State mutex during sync RPC calls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: build
 on:
   push:
     # Sequence of patterns matched against refs/heads
-    branches:
-      # Provide the release branch
+    branches: [ crt-release-migration-1.11.x ]
 
 env:
   PKG_NAME: consul


### PR DESCRIPTION
## Overview

Consul's '[anti-entropy'](https://www.consul.io/docs/architecture/anti-entropy)' feature depends on periodic sync of state changes from a local client Agent to the remote Server:

> anti-entropy is a synchronization of the local agent state and the catalog. For example, when a user registers a new service or check with the agent, the agent in turn notifies the catalog that this new check exists. Similarly, when a check is deleted from the agent, it is consequently removed from the catalog as well.

This synchronization occurs in `local.SyncChanges()`: https://github.com/wjordan/consul/blob/0854e1d68450103e5c84360e4479a6ed54bdeef9/agent/local/state.go#L1173-L1228

Note the ([`sync.RWMutex`](https://pkg.go.dev/sync#RWMutex)) `l.Lock()` / `defer l.Unlock()` at the start of this function. This lock prevents _any_ other reads of the local agent state while SyncChanges is in progress. Unfortunately, actually synchronizing changes to the catalog requires RPC calls to `Catalog.Register` (`syncNodeInfo`, `syncService`, `syncCheck`) / `Catalog.Deregister` (`deleteService`, `deleteCheck`), which may block for a long time in conditions of high latency or intermittent network issues. This results in long blocking calls for agent-local queries, causing unexpected application delays. Agent-local queries are expected to respond more quickly than RPC calls, but with the mutex the latency is identical to an RPC call when a `SyncChanges` is in progress.

## Solution

The solution in this PR is to temporarily unlock the mutex during the `SyncChanges`-initiated RPC calls by wrapping them with `l.Unlock() / l.Lock()`. This allows other agent queries to take place while a catalog update is in-flight.

I also reorganized the logic to update the local state, so that the local state is updated _before_ the RPC call, and rolled back (the original state before changes is restored) in the error case. This way, any additional updates to local state arriving while the RPC call is in-flight would set `InSync = false` properly and be correctly included in the next sync.