### PR TITLE
Fix fine-grained blocking queries for Catalog.NodeServices

### DIFF
--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1455,7 +1455,8 @@ func TestStateStore_EnsureService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if idx != 30 {
+	// Index matches the requested node's latest service update.
+	if idx != 20 {
 		t.Fatalf("bad index: %d", idx)
 	}
 


### PR DESCRIPTION
Add per-node entries to the index table to track the latest raft index for an individual node and its services.
Prevents blocking queries from returning immediately when the specific node hasn't been updated.