### PR TITLE
Add 'sync=false' query param to skip sync on agent service updates

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -294,6 +294,9 @@ type ServiceRegisterOpts struct {
 	// having to manually deregister checks.
 	ReplaceExistingChecks bool
 
+	// Prevent syncing (possibly blocking) with the server
+	SkipSync bool
+
 	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use WithContext() to set the context.
 	ctx context.Context
@@ -779,6 +782,7 @@ func (a *Agent) MembersOpts(opts MembersOpts) ([]*AgentMember, error) {
 func (a *Agent) ServiceRegister(service *AgentServiceRegistration) error {
 	opts := ServiceRegisterOpts{
 		ReplaceExistingChecks: false,
+		SkipSync:              false,
 	}
 
 	return a.serviceRegister(service, opts)
@@ -796,6 +800,9 @@ func (a *Agent) serviceRegister(service *AgentServiceRegistration, opts ServiceR
 	r.ctx = opts.ctx
 	if opts.ReplaceExistingChecks {
 		r.params.Set("replace-existing-checks", "true")
+	}
+	if opts.SkipSync {
+		r.params.Set("sync", "false")
 	}
 	_, resp, err := a.c.doRequest(r)
 	if err != nil {

--- a/api/api.go
+++ b/api/api.go
@@ -184,6 +184,10 @@ type QueryOptions struct {
 	// Filter requests filtering data prior to it being returned. The string
 	// is a go-bexpr compatible expression.
 	Filter string
+
+	// Skip syncing with the server, a potentially-blocking operation
+	// but still queue a sync for later
+	SkipSync bool
 }
 
 func (o *QueryOptions) Context() context.Context {
@@ -831,6 +835,10 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 		if len(cc) > 0 {
 			r.header.Set("Cache-Control", strings.Join(cc, ", "))
 		}
+	}
+
+	if q.SkipSync {
+		r.params.Set("sync", "false")
 	}
 
 	r.ctx = q.ctx


### PR DESCRIPTION
This lets you update endpoints in the local agent without blocking the response on syncing those changes to the Consul server, by passing a `sync=false` query param to the agent update endpoints.